### PR TITLE
Update to 0.1.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,17 +1,17 @@
-{% set opensensus_version = "0.7.10" %}
-{% set version = "0.1.2" %}
+{% set opencensus_version = "0.11.2" %}
+{% set version = "0.1.3" %}
 
 package:
   name: opencensus-context
   version: {{ version }}
 
 source:
-  url: https://github.com/census-instrumentation/opencensus-python/archive/v{{ opensensus_version }}.zip
-  sha256: 4ea0b5bac55c62f9ca5ddccc5acf8160c3575bf58bc5dab7bcb1f5a9cc578e71
+  url: https://github.com/census-instrumentation/opencensus-python/archive/v{{ opencensus_version }}.zip
+  sha256: 3e2ed9735e49ea324d402af576d8504fab6a7f664c8c6f20820e1abf242c138
 
 build:
-  number: 4
-  script: "cd context/opencensus-context && {{ PYTHON }} -m pip install . -vv"
+  number: 0
+  script: "cd context/opencensus-context && {PYTHON} -m pip install . -vv --no-deps --no-build-isolation"
 
 requirements:
   host:
@@ -19,11 +19,15 @@ requirements:
     - pip
   run:
     - python
-    - contextvars  # [py<=3.7]
+    - contextvars  # [py==36]
 
 test:
   imports:
     - opencensus.common.runtime_context
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/census-instrumentation/opencensus-python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/census-instrumentation/opencensus-python/archive/v{{ opencensus_version }}.zip
+  url: https://github.com/census-instrumentation/opencensus-python/archive/v{{ opencensus_version }}.tar.gz
   sha256: 3e2ed9735e49ea324d402af576d8504fab6a7f664c8c6f20820e1abf242c138
 
 build:
@@ -16,6 +16,7 @@ build:
 requirements:
   host:
     - python
+    - wheel
     - pip
   run:
     - python
@@ -32,6 +33,7 @@ test:
 about:
   home: https://github.com/census-instrumentation/opencensus-python
   license: Apache-2.0
+  license_family: Apache
   license_file: LICENSE
   summary: The OpenCensus Runtime Context.
   description: |

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,3 @@
-{% set opencensus_version = "0.11.2" %}
 {% set version = "0.1.3" %}
 
 package:
@@ -6,16 +5,17 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/census-instrumentation/opencensus-python/archive/v{{ opencensus_version }}.tar.gz
-  sha256: 3e2ed9735e49ea324d402af576d8504fab6a7f664c8c6f20820e1abf242c1384
+  url: https://files.pythonhosted.org/packages/4c/96/3b6f638f6275a8abbd45e582448723bffa29c1fb426721dedb5c72f7d056/opencensus-context-{{ version }}.tar.gz
+  sha256: a03108c3c10d8c80bb5ddf5c8a1f033161fa61972a9917f9b9b3a18517f0088c
 
 build:
   number: 0
-  script: "cd context/opencensus-context && {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation"
+  script: "{{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation"
 
 requirements:
   host:
     - python
+    - setuptools
     - wheel
     - pip
   run:
@@ -34,7 +34,7 @@ about:
   home: https://github.com/census-instrumentation/opencensus-python
   license: Apache-2.0
   license_family: Apache
-  license_file: LICENSE
+  # The PyPi sources don't include a LICENSE file.
   summary: The OpenCensus Runtime Context.
   description: |
     The OpenCensus Runtime Context provides in-process context propagation.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,11 +7,11 @@ package:
 
 source:
   url: https://github.com/census-instrumentation/opencensus-python/archive/v{{ opencensus_version }}.tar.gz
-  sha256: 3e2ed9735e49ea324d402af576d8504fab6a7f664c8c6f20820e1abf242c138
+  sha256: 3e2ed9735e49ea324d402af576d8504fab6a7f664c8c6f20820e1abf242c1384
 
 build:
   number: 0
-  script: "cd context/opencensus-context && {PYTHON} -m pip install . -vv --no-deps --no-build-isolation"
+  script: "cd context/opencensus-context && {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation"
 
 requirements:
   host:


### PR DESCRIPTION
This package has technically been deprecated, but we require its last supported version because a major package (`ray`) depends on `opencensus`, which in turn depends on this package.